### PR TITLE
feat: aes-gcm supports arbitrary length of plaintext and aad

### DIFF
--- a/circuits/aes-gcm/aes-gcm-general.circom
+++ b/circuits/aes-gcm/aes-gcm-general.circom
@@ -1,0 +1,222 @@
+pragma circom 2.1.9;
+
+include "ghash.circom";
+include "aes/cipher.circom";
+include "utils.circom";
+include "gctr.circom";
+
+
+/// AES-GCM with 128 bit key authenticated encryption according to: https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38d.pdf
+///
+/// Parameters:
+/// _al: length of aad
+/// _cl: length of the plaintext
+///
+/// Inputs:
+/// key: 128-bit key
+/// iv: initialization vector
+/// plainText: plaintext to be encrypted
+/// aad: additional data to be authenticated
+///
+/// Outputs:
+/// cipherText: encrypted ciphertext
+/// authTag: authentication tag
+///
+template AESGCMGENERAL(_al, _cl) {
+    // Inputs
+    signal input key[16]; // 128-bit key
+    signal input iv[12]; // IV length is 96 bits (12 bytes)
+    signal input plainText[_cl];
+    signal input aad[_al]; // AAD length is 128 bits (16 bytes)
+
+    // Outputs
+    signal output cipherText[_cl];
+    signal output authTag[16]; //   Authentication tag length is 128 bits (16 bytes)
+    
+    var al = _al;
+    if (al % 16 > 0) {
+        al += 16 - al % 16;
+    }
+
+    var cl = _cl;
+    if (cl % 16 > 0) {
+        cl += 16 - cl % 16;
+    }
+
+    signal _plainText[cl];
+    signal _aad[al];
+
+    for (var i = 0; i < _cl; i++) {
+        _plainText[i] <== plainText[i];
+    }
+
+    for (var i = _cl; i < cl; i++) {
+        _plainText[i] <== 0;
+    }
+
+    for (var i = 0; i < _al; i++) {
+        _aad[i] <== aad[i];
+    }
+
+    for (var i = _al; i < al; i++) {
+        _aad[i] <== 0;
+    }
+
+    component zeroBlock = ToBlocks(16);
+    for (var i = 0; i < 16; i++) {
+        zeroBlock.stream[i] <== 0;
+    }
+
+    // Step 1: Let H = aes(key, zeroBlock)
+    component cipherH = Cipher();
+    cipherH.key <== key;
+    cipherH.block <== zeroBlock.blocks[0];
+
+    // Step 2: Define a block, J0 with 96 bits of iv and 32 bits of 0s
+    component J0builder = ToBlocks(16);
+    for (var i = 0; i < 12; i++) {
+        J0builder.stream[i] <== iv[i];
+    }
+    for (var i = 12; i < 16; i++) {
+        J0builder.stream[i] <== 0;
+    }
+    component J0WordIncrementer = IncrementWord();
+    J0WordIncrementer.in <== J0builder.blocks[0][3];
+
+    component J0WordIncrementer2 = IncrementWord();
+    J0WordIncrementer2.in <== J0WordIncrementer.out;
+
+    signal J0[4][4];
+    for (var i = 0; i < 3; i++) {
+        J0[i] <== J0builder.blocks[0][i];
+    }
+    J0[3] <== J0WordIncrementer2.out;
+
+    // Step 3: Let C = GCTRK(inc32(J0), P)
+    component gctr = GCTR(cl);
+    gctr.key <== key;
+    gctr.initialCounterBlock <== J0;
+    gctr.plainText <== _plainText;
+
+    // Step 4: Let u and v (v is always zero with out key size and aad length)
+    var cBlockCount = cl \ 16;
+    var aBlockCount = al \ 16;
+    // so the reason there is a plus two is because 
+    // the first block is the aad 
+    // the second is the ciphertext
+    // the last is the length of the aad and ciphertext
+    // i.e. S = GHASHH (A || C || [len(A)] || [len(C)]). <- which is always 48 bytes: 3 blocks
+    var ghashblocks = aBlockCount + cBlockCount + 1; 
+    signal ghashMessage[ghashblocks][4][4];
+
+    // set aad as first block
+    component additionalBlocks = ToBlocks(al);
+    additionalBlocks.stream <== _aad;
+
+    for (var i=0; i<aBlockCount; i++) {
+        ghashMessage[i] <== additionalBlocks.blocks[i];
+    }
+
+    // set cipher text block padded
+    component ciphertextBlocks = ToBlocks(cl);
+    ciphertextBlocks.stream <== gctr.cipherText;
+
+    for (var i=0; i<cBlockCount-1; i++) {
+        ghashMessage[i+aBlockCount] <== ciphertextBlocks.blocks[i];
+    }
+
+    var lastBlockLen = _cl % 16;
+    if (lastBlockLen == 0) {
+        lastBlockLen = 16;
+    }
+
+    for  (var i = 0; i < lastBlockLen; i++) {
+        ghashMessage[aBlockCount+cBlockCount-1][i%4][i\4] <== ciphertextBlocks.blocks[cBlockCount-1][i%4][i\4];
+    }
+
+    // if padding zero in plaintext, it should still be zero in ghash msg
+    if (_cl % 16 > 0) {
+        for (var i = 0; i < 16 - _cl % 16; i++) {
+            ghashMessage[aBlockCount+cBlockCount-1][3-i%4][3-i\4] <== 0;
+        }
+    }
+
+    // length of aad
+    var a_len = _al * 8;
+    for (var i=0; i<8; i++) {
+        var byte_value = 0;
+        for (var j=0; j<8; j++) {
+            byte_value *= 2;
+            byte_value += (a_len >> ((7-i)*8+(7-j))) & 1;
+        }
+        ghashMessage[ghashblocks-1][i%4][i\4] <== byte_value;
+    }
+
+    var c_len = _cl * 8;
+    for (var i=0; i<8; i++) {
+        var byte_value = 0;
+        for (var j=0; j<8; j++) {
+            byte_value *= 2;
+            byte_value += (c_len >> (7-i)*8+(7-j)) & 1;
+        }
+        ghashMessage[ghashblocks-1][i%4][i\4+2] <== byte_value;
+    }
+
+    // Step 5: Define a block, S
+    // needs to take in the number of blocks
+    component ghash = GHASH(ghashblocks);
+    component hashKeyToStream = ToStream(1, 16);
+    hashKeyToStream.blocks[0] <== cipherH.cipher;
+    ghash.HashKey <== hashKeyToStream.stream;
+    // S = GHASHH (A || 0^v || C || 0^u || [len(A)] || [len(C)]).
+    component selectedBlocksToStream[ghashblocks];
+    for (var i = 0 ; i<ghashblocks ; i++) {
+        ghash.msg[i] <== ToStream(1, 16)([ghashMessage[i]]);
+    }
+
+    // signal bytes[16];
+    // ghash_tag <== ghash.tag;
+    // signal tagBytes[16 * 8] <== BytesToBits(16)(ghash.tag);
+    // for(var i = 0; i < 16; i++) {
+    //     var byteValue = 0;
+    //     var sum=1;
+    //     for(var j = 0; j<8; j++) {
+    //         var bitIndex = i*8+j;
+    //         byteValue += tagBytes[bitIndex]*sum;
+    //         sum = sum*sum;
+    //     }
+    //     bytes[i] <== byteValue;
+    // }
+
+    // pre step 6: restore the g0
+    component g0builder = ToBlocks(16);
+    for (var i = 0; i < 12; i++) {
+        g0builder.stream[i] <== iv[i];
+    }
+    for (var i = 12; i < 16; i++) {
+        g0builder.stream[i] <== 0;
+    }
+    component g0WordIncrementer = IncrementWord();
+    g0WordIncrementer.in <== g0builder.blocks[0][3];
+
+    signal g0[4][4];
+    for (var i = 0; i < 3; i++) {
+        g0[i] <== g0builder.blocks[0][i];
+    }
+    g0[3] <== g0WordIncrementer.out;
+
+    // Step 6: Let T = MSBt(GCTRK(J0, S))
+    component gctrT = GCTR(16);
+    gctrT.key <== key;
+    // gctrT.initialCounterBlock <== J0;
+    gctrT.initialCounterBlock <== g0;
+    // gctrT.plainText <== bytes;
+    gctrT.plainText <== ghash.tag;
+
+    authTag <== gctrT.cipherText;
+
+    for (var i = 0; i < _cl; i++) {
+        cipherText[i] <== gctr.cipherText[i];
+    }
+    // cipherText <== gctr.cipherText;
+}

--- a/circuits/test/aes-gcm/aes-gcm-general.test.ts
+++ b/circuits/test/aes-gcm/aes-gcm-general.test.ts
@@ -1,0 +1,112 @@
+import { assert } from "chai";
+import { WitnessTester } from "circomkit";
+import { circomkit, hexBytesToBigInt, hexToBytes } from "../common";
+
+describe("aes-gcm-general", () => {
+  let circuit: WitnessTester<["key", "iv", "plainText", "aad"], ["cipherText", "authTag"]>;
+
+  before(async () => {
+    circuit = await circomkit.WitnessTester(`aes-gcm-general`, {
+      file: "aes-gcm/aes-gcm-general",
+      template: "AESGCMGENERAL",
+      params: [16, 16],
+    });
+  });
+
+  it("should have correct output", async () => {
+    let key = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let plainText = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let iv = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let HashKey = [0x66, 0xe9, 0x4b, 0xd4, 0xef, 0x8a, 0x2c, 0x3b, 0x88, 0x4c, 0xfa, 0x59, 0xca, 0x34, 0x2b, 0x2e];
+    let aad = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    let expected_output = [0x03, 0x88, 0xda, 0xce, 0x60, 0xb6, 0xa3, 0x92, 0xf3, 0x28, 0xc2, 0xb9, 0x71, 0xb2, 0xfe, 0x78];
+
+    const witness = await circuit.compute({ key: key, iv: iv, plainText: plainText, aad: aad }, ["cipherText", "authTag"])
+
+    assert.deepEqual(witness.cipherText, hexBytesToBigInt(expected_output))
+  });
+
+  it("should work for self generated test case", async () => {
+    let circuit_one_block: WitnessTester<["key", "iv", "plainText", "aad"], ["cipherText", "authTag"]>;
+    circuit_one_block = await circomkit.WitnessTester(`aes-gcm-general`, {
+      file: "aes-gcm/aes-gcm-general",
+      template: "AESGCMGENERAL",
+      params: [16, 16],
+    });
+
+    const key = hexToBytes('31313131313131313131313131313131');
+    const iv = hexToBytes('313131313131313131313131');
+    const msg = hexToBytes('7465737468656c6c6f30303030303030');
+    const aad = hexToBytes('00000000000000000000000000000000')
+    const ct = hexToBytes('2929d2bb1ae94804402b8e776e0d3356');
+    const auth_tag = hexToBytes('9a636f50dc842820c798d001d9a9c4bd');
+
+    const witness = await circuit_one_block.compute({ key: key, iv: iv, plainText: msg, aad: aad }, ["cipherText", "authTag"])
+
+    assert.deepEqual(witness.cipherText, hexBytesToBigInt(ct))
+    assert.deepEqual(witness.authTag, hexBytesToBigInt(auth_tag));
+  });
+
+  it("should work for multiple blocks", async () => {
+    let circuit_one_block: WitnessTester<["key", "iv", "plainText", "aad"], ["cipherText", "authTag"]>;
+    circuit_one_block = await circomkit.WitnessTester(`aes-gcm-general`, {
+      file: "aes-gcm/aes-gcm-general",
+      template: "AESGCMGENERAL",
+      params: [16, 32],
+    });
+
+    const key = hexToBytes('31313131313131313131313131313131');
+    const iv = hexToBytes('313131313131313131313131');
+    const msg = hexToBytes('7465737468656c6c6f303030303030307465737468656c6c6f30303030303030');
+    const aad = hexToBytes('00000000000000000000000000000000')
+    const ct = hexToBytes('2929d2bb1ae94804402b8e776e0d335626756530713e4c065af1d3c4f56e0204');
+    const auth_tag = hexToBytes('d54d14668b92ce3e5b13880067df54d6');
+
+    const witness = await circuit_one_block.compute({ key: key, iv: iv, plainText: msg, aad: aad }, ["cipherText", "authTag"])
+
+    assert.deepEqual(witness.cipherText, hexBytesToBigInt(ct))
+    assert.deepEqual(witness.authTag, hexBytesToBigInt(auth_tag));
+  });
+
+  it("should work for arbitrary length of aad and plaintext", async () => {
+    let circuit_multiblock: WitnessTester<["key", "iv", "plainText", "aad"], ["cipherText", "authTag"]>;
+    circuit_multiblock = await circomkit.WitnessTester(`aes-gcm-general`, {
+      file: "aes-gcm/aes-gcm-general",
+      template: "AESGCMGENERAL",
+      params: [20, 40],
+    });
+
+    const key      = hexToBytes('0102030405060708090a0b0c0d0e0f10');
+    const iv       = hexToBytes('102030405060708090a0b0c0');
+    const msg      = hexToBytes('0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728');
+    const aad      = hexToBytes('0102030405060708090a0b0c0d0e0f1011121314');
+    const ct       = hexToBytes('e8a37cd1b913dfc89a3c469f2b8d6fc5dea1f7a17b3f2bece8e0179414e9209f817e848bde94e2a8');
+    const auth_tag = hexToBytes('dec66aa48b49c2d1801c16aa3bdf9c29');
+
+    const witness    = await circuit_multiblock.compute({key: key, iv: iv, plainText: msg, aad: aad}, ["cipherText", "authTag"]);
+    const cipherText = witness.cipherText.toString();
+    const ct_str     = ct.toString();
+
+    assert.deepEqual(cipherText.slice(0, ct_str.length), ct_str);
+    assert.deepEqual(witness.authTag, hexBytesToBigInt(auth_tag));
+  })
+});
+
+// signal input key[16]; // 128-bit key
+// signal input iv[12]; // IV length is 96 bits (12 bytes)
+// signal input plainText[l];
+// signal input additionalData[16]; // AAD length is 128 bits (16 bytes)
+
+// K = 00000000000000000000000000000000
+// P = 00000000000000000000000000000000
+// IV = 000000000000000000000000
+// H = 66e94bd4ef8a2c3b884cfa59ca342b2e
+// Y0 = 00000000000000000000000000000001                                58E2FCCEFA7E3061367F1D57A4E7455A
+// E(K, Y0) = 58e2fccefa7e3061367f1d57a4e7455a ==> This is our output?? 58E2FCCEFA7E3061367F1D57A4E7455A
+// Y1 = 00000000000000000000000000000002
+// E(K, Y1) = 0388dace60b6a392f328c2b971b2fe78
+// X1 = 5e2ec746917062882c85b0685353deb7
+// len(A)||len(C) = 00000000000000000000000000000080
+// GHASH(H, A, C) = f38cbb1ad69223dcc3457ae5b6b0f885
+// C = 0388dace60b6a392f328c2b971b2fe78
+// T = ab6e47d42cec13bdf53a67b21257bddf

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "circomkit": "^0.2.1",
-        "circomlib": "^2.0.5",
-        "parser-attestor": "github:pluto/parser-attestor#b9feeeb240ddf867da85198de7d59e73cba4b008"
+        "circomlib": "^2.0.5"
       },
       "devDependencies": {
         "@types/chai": "^4.3.17",
@@ -136,36 +135,6 @@
       "integrity": "sha512-x37Jsv1vx6I6RMJdfvYEmDUOLYgzYMecwlk13gniDOcN20xLVe9hy9DlQxWeCPirqpDY/jwugQSqCi2RxehU3g==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@zk-email/circuits": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@zk-email/circuits/-/circuits-6.2.0.tgz",
-      "integrity": "sha512-G68nAwl4svlE4pCxytgV7NLz80uUCmwzFFdMZ0qcvqzccT1ytMsay19cV1tcKJdzDrMWphGXjxpCNtn+lb7NXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@zk-email/zk-regex-circom": "^2.1.0",
-        "circomlib": "^2.0.5"
-      }
-    },
-    "node_modules/@zk-email/zk-regex-circom": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@zk-email/zk-regex-circom/-/zk-regex-circom-2.2.0.tgz",
-      "integrity": "sha512-4uCHad2AhNjl+gBkRZPv+mTHrXEGV1atte76gaIN4rTsIxZZxHsQ0h66n16Td/UiqE4vjjpt2cGfEzMnhmFtoA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^11.0.0",
-        "snarkjs": "^0.7.0"
-      }
-    },
-    "node_modules/@zk-email/zk-regex-circom/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/acorn": {
       "version": "8.12.1",
@@ -504,6 +473,7 @@
       "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.25.tgz",
       "integrity": "sha512-xBGsBFF5Uv6AKvbpgExYqpHfmfawH2HKe+LyjfKSRevqEV8u63i9KGHVIILsbJNW+0c5bm/66f0PUYQ7qZSkJA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "ffjavascript": "0.3.0"
       },
@@ -516,6 +486,7 @@
       "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.3.0.tgz",
       "integrity": "sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==",
       "license": "GPL-3.0",
+      "peer": true,
       "dependencies": {
         "wasmbuilder": "0.0.16",
         "wasmcurves": "0.2.2",
@@ -1613,16 +1584,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parser-attestor": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/pluto/parser-attestor.git#b9feeeb240ddf867da85198de7d59e73cba4b008",
-      "integrity": "sha512-8yldptobgJKXHzSpb1/xdtEQLHqzGb55bqrdyTbapyZ1zR482FKiS4RXw8gXKwKGLQK0WNSumYDbh8BBqlJGgw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@zk-email/circuits": "^6.1.1",
-        "circomlib": "^2.0.5"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1790,6 +1751,7 @@
       "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.7.4.tgz",
       "integrity": "sha512-x4cOCR4YXSyBlLtfnUUwfbZrw8wFd/Y0lk83eexJzKwZB8ELdpH+10ts8YtDsm2/a3WK7c7p514bbE8NpqxW8w==",
       "license": "GPL-3.0",
+      "peer": true,
       "dependencies": {
         "@iden3/binfileutils": "0.0.12",
         "bfj": "^7.0.2",
@@ -1811,6 +1773,7 @@
       "resolved": "https://registry.npmjs.org/@iden3/binfileutils/-/binfileutils-0.0.12.tgz",
       "integrity": "sha512-naAmzuDufRIcoNfQ1d99d7hGHufLA3wZSibtr4dMe6ZeiOPV1KwOZWTJ1YVz4HbaWlpDuzVU72dS4ATQS4PXBQ==",
       "license": "GPL-3.0",
+      "peer": true,
       "dependencies": {
         "fastfile": "0.0.20",
         "ffjavascript": "^0.3.0"
@@ -1821,6 +1784,7 @@
       "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.3.0.tgz",
       "integrity": "sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==",
       "license": "GPL-3.0",
+      "peer": true,
       "dependencies": {
         "wasmbuilder": "0.0.16",
         "wasmcurves": "0.2.2",
@@ -1832,6 +1796,7 @@
       "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.48.tgz",
       "integrity": "sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==",
       "license": "GPL-3.0",
+      "peer": true,
       "dependencies": {
         "@iden3/bigarray": "0.0.2",
         "@iden3/binfileutils": "0.0.12",


### PR DESCRIPTION
This PR adds following features

- `aes-gcm-general.circom` supports arbitrary length of `plaintext` and `aad`, and it works well with `authTag` which is not correct in the current `aes-gcm.circom`.

- The corresponding test module is located at `test/aes-gcm/aes-gcm-general.test.ts`, which includes all the tests from `aes-gcm.test.ts` as well as the additional test case for the new feature. All test cases are verified using the standard AES-GCM.